### PR TITLE
ES7 exponentiation operator support + symbol print/println tweaks

### DIFF
--- a/build/external/jshint/jshint.js
+++ b/build/external/jshint/jshint.js
@@ -13967,7 +13967,14 @@ Lexer.prototype = {
         value: "==="
       };
     }
-
+	 
+	 if (ch1 === "*" && ch2 === "*" && ch3 === "=") {
+      return {
+        type: Token.Punctuator,
+        value: "**="
+      };
+    }
+	 
     if (ch1 === "!" && ch2 === "=" && ch3 === "=") {
       return {
         type: Token.Punctuator,
@@ -14006,7 +14013,7 @@ Lexer.prototype = {
 
     // 2-character punctuators: <= >= == != ++ -- << >> && ||
     // += -= *= %= &= |= ^= /=
-    if (ch1 === ch2 && ("+-<>&|".indexOf(ch1) >= 0)) {
+    if (ch1 === ch2 && ("+-<>*&|".indexOf(ch1) >= 0)) {
       return {
         type: Token.Punctuator,
         value: ch1 + ch2
@@ -20969,6 +20976,7 @@ var JSHINT = (function() {
   assignop("+=", "assignadd", 20);
   assignop("-=", "assignsub", 20);
   assignop("*=", "assignmult", 20);
+  assignop("**=", "assignexp", 20);
   assignop("/=", "assigndiv", 20).nud = function() {
     error("E014");
   };
@@ -21153,6 +21161,7 @@ var JSHINT = (function() {
     this.right = expression(130);
     return this;
   }, 130);
+  infix("**", "exp", 140);
   infix("*", "mult", 140);
   infix("/", "div", 140);
   infix("%", "mod", 140);

--- a/build/external/jshint/jshint.js
+++ b/build/external/jshint/jshint.js
@@ -14011,7 +14011,7 @@ Lexer.prototype = {
       };
     }
 
-    // 2-character punctuators: <= >= == != ++ -- << >> && ||
+    // 2-character punctuators: <= >= == != ++ -- << >> && || **
     // += -= *= %= &= |= ^= /=
     if (ch1 === ch2 && ("+-<>*&|".indexOf(ch1) >= 0)) {
       return {

--- a/build/js/live-editor.editor_ace_deps.js
+++ b/build/js/live-editor.editor_ace_deps.js
@@ -27867,112 +27867,6 @@ var dom = require("../lib/dom");
 dom.importCssString(exports.cssText, exports.cssClass);
 });
 
-ace.define("ace/theme/monokai",["require","exports","module","ace/lib/dom"], function(require, exports, module) {
-
-exports.isDark = true;
-exports.cssClass = "ace-monokai";
-exports.cssText = ".ace-monokai .ace_gutter {\
-background: #2F3129;\
-color: #8F908A\
-}\
-.ace-monokai .ace_print-margin {\
-width: 1px;\
-background: #555651\
-}\
-.ace-monokai {\
-background-color: #272822;\
-color: #F8F8F2\
-}\
-.ace-monokai .ace_cursor {\
-color: #F8F8F0\
-}\
-.ace-monokai .ace_marker-layer .ace_selection {\
-background: #49483E\
-}\
-.ace-monokai.ace_multiselect .ace_selection.ace_start {\
-box-shadow: 0 0 3px 0px #272822;\
-}\
-.ace-monokai .ace_marker-layer .ace_step {\
-background: rgb(102, 82, 0)\
-}\
-.ace-monokai .ace_marker-layer .ace_bracket {\
-margin: -1px 0 0 -1px;\
-border: 1px solid #49483E\
-}\
-.ace-monokai .ace_marker-layer .ace_active-line {\
-background: #202020\
-}\
-.ace-monokai .ace_gutter-active-line {\
-background-color: #272727\
-}\
-.ace-monokai .ace_marker-layer .ace_selected-word {\
-border: 1px solid #49483E\
-}\
-.ace-monokai .ace_invisible {\
-color: #52524d\
-}\
-.ace-monokai .ace_entity.ace_name.ace_tag,\
-.ace-monokai .ace_keyword,\
-.ace-monokai .ace_meta.ace_tag,\
-.ace-monokai .ace_storage {\
-color: #F92672\
-}\
-.ace-monokai .ace_punctuation,\
-.ace-monokai .ace_punctuation.ace_tag {\
-color: #fff\
-}\
-.ace-monokai .ace_constant.ace_character,\
-.ace-monokai .ace_constant.ace_language,\
-.ace-monokai .ace_constant.ace_numeric,\
-.ace-monokai .ace_constant.ace_other {\
-color: #AE81FF\
-}\
-.ace-monokai .ace_invalid {\
-color: #F8F8F0;\
-background-color: #F92672\
-}\
-.ace-monokai .ace_invalid.ace_deprecated {\
-color: #F8F8F0;\
-background-color: #AE81FF\
-}\
-.ace-monokai .ace_support.ace_constant,\
-.ace-monokai .ace_support.ace_function {\
-color: #66D9EF\
-}\
-.ace-monokai .ace_fold {\
-background-color: #A6E22E;\
-border-color: #F8F8F2\
-}\
-.ace-monokai .ace_storage.ace_type,\
-.ace-monokai .ace_support.ace_class,\
-.ace-monokai .ace_support.ace_type {\
-font-style: italic;\
-color: #66D9EF\
-}\
-.ace-monokai .ace_entity.ace_name.ace_function,\
-.ace-monokai .ace_entity.ace_other,\
-.ace-monokai .ace_entity.ace_other.ace_attribute-name,\
-.ace-monokai .ace_variable {\
-color: #A6E22E\
-}\
-.ace-monokai .ace_variable.ace_parameter {\
-font-style: italic;\
-color: #FD971F\
-}\
-.ace-monokai .ace_string {\
-color: #E6DB74\
-}\
-.ace-monokai .ace_comment {\
-color: #75715E\
-}\
-.ace-monokai .ace_indent-guide {\
-background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWPQ0FD0ZXBzd/wPAAjVAoxeSgNeAAAAAElFTkSuQmCC) right repeat-y\
-}";
-
-var dom = require("../lib/dom");
-dom.importCssString(exports.cssText, exports.cssClass);
-});
-
 ace.define("ace/theme/mono_industrial",["require","exports","module","ace/lib/dom"], function(require, exports, module) {
 
 exports.isDark = true;
@@ -28075,6 +27969,112 @@ color: #A65EFF\
 }\
 .ace-mono-industrial .ace_indent-guide {\
 background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWNQ1NbwZfALD/4PAAlTArlEC4r/AAAAAElFTkSuQmCC) right repeat-y\
+}";
+
+var dom = require("../lib/dom");
+dom.importCssString(exports.cssText, exports.cssClass);
+});
+
+ace.define("ace/theme/monokai",["require","exports","module","ace/lib/dom"], function(require, exports, module) {
+
+exports.isDark = true;
+exports.cssClass = "ace-monokai";
+exports.cssText = ".ace-monokai .ace_gutter {\
+background: #2F3129;\
+color: #8F908A\
+}\
+.ace-monokai .ace_print-margin {\
+width: 1px;\
+background: #555651\
+}\
+.ace-monokai {\
+background-color: #272822;\
+color: #F8F8F2\
+}\
+.ace-monokai .ace_cursor {\
+color: #F8F8F0\
+}\
+.ace-monokai .ace_marker-layer .ace_selection {\
+background: #49483E\
+}\
+.ace-monokai.ace_multiselect .ace_selection.ace_start {\
+box-shadow: 0 0 3px 0px #272822;\
+}\
+.ace-monokai .ace_marker-layer .ace_step {\
+background: rgb(102, 82, 0)\
+}\
+.ace-monokai .ace_marker-layer .ace_bracket {\
+margin: -1px 0 0 -1px;\
+border: 1px solid #49483E\
+}\
+.ace-monokai .ace_marker-layer .ace_active-line {\
+background: #202020\
+}\
+.ace-monokai .ace_gutter-active-line {\
+background-color: #272727\
+}\
+.ace-monokai .ace_marker-layer .ace_selected-word {\
+border: 1px solid #49483E\
+}\
+.ace-monokai .ace_invisible {\
+color: #52524d\
+}\
+.ace-monokai .ace_entity.ace_name.ace_tag,\
+.ace-monokai .ace_keyword,\
+.ace-monokai .ace_meta.ace_tag,\
+.ace-monokai .ace_storage {\
+color: #F92672\
+}\
+.ace-monokai .ace_punctuation,\
+.ace-monokai .ace_punctuation.ace_tag {\
+color: #fff\
+}\
+.ace-monokai .ace_constant.ace_character,\
+.ace-monokai .ace_constant.ace_language,\
+.ace-monokai .ace_constant.ace_numeric,\
+.ace-monokai .ace_constant.ace_other {\
+color: #AE81FF\
+}\
+.ace-monokai .ace_invalid {\
+color: #F8F8F0;\
+background-color: #F92672\
+}\
+.ace-monokai .ace_invalid.ace_deprecated {\
+color: #F8F8F0;\
+background-color: #AE81FF\
+}\
+.ace-monokai .ace_support.ace_constant,\
+.ace-monokai .ace_support.ace_function {\
+color: #66D9EF\
+}\
+.ace-monokai .ace_fold {\
+background-color: #A6E22E;\
+border-color: #F8F8F2\
+}\
+.ace-monokai .ace_storage.ace_type,\
+.ace-monokai .ace_support.ace_class,\
+.ace-monokai .ace_support.ace_type {\
+font-style: italic;\
+color: #66D9EF\
+}\
+.ace-monokai .ace_entity.ace_name.ace_function,\
+.ace-monokai .ace_entity.ace_other,\
+.ace-monokai .ace_entity.ace_other.ace_attribute-name,\
+.ace-monokai .ace_variable {\
+color: #A6E22E\
+}\
+.ace-monokai .ace_variable.ace_parameter {\
+font-style: italic;\
+color: #FD971F\
+}\
+.ace-monokai .ace_string {\
+color: #E6DB74\
+}\
+.ace-monokai .ace_comment {\
+color: #75715E\
+}\
+.ace-monokai .ace_indent-guide {\
+background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAEklEQVQImWPQ0FD0ZXBzd/wPAAjVAoxeSgNeAAAAAElFTkSuQmCC) right repeat-y\
 }";
 
 var dom = require("../lib/dom");

--- a/build/js/live-editor.output_pjs.js
+++ b/build/js/live-editor.output_pjs.js
@@ -168,6 +168,7 @@ var PJSCodeInjector = (function () {
                 this.processing.isNaN = window.isNaN;
                 this.processing.Number = window.Number;
                 this.processing.Date = window.Date;
+                this.processing.Symbol = window.Symbol;
             }
 
             Object.assign(this.processing, {
@@ -178,7 +179,7 @@ var PJSCodeInjector = (function () {
                 /*loadImage: (file) => {
                     throw {message: "Use getImage instead of loadImage."};
                 },
-                  requestImage: (file) => {
+                 requestImage: (file) => {
                     throw {message: "Use getImage instead of requestImage."};
                 },*/
 

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -57879,7 +57879,9 @@ ASTTransforms.rewriteContextVariables = function (envName, context) {
 
                             return {
                                 type: "SequenceExpression",
-                                expressions: node.declarations.map(function (decl) {
+                                expressions: node.declarations.filter(function (d) {
+                                    return d.init !== null;
+                                }).map(function (decl) {
                                     return b.AssignmentExpression(b.MemberExpression(b.Identifier(envName), b.Identifier(decl.id.name)), "=", decl.init);
                                 })
                             };

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -34103,7 +34103,14 @@ Lexer.prototype = {
         value: "==="
       };
     }
-
+	 
+	 if (ch1 === "*" && ch2 === "*" && ch3 === "=") {
+      return {
+        type: Token.Punctuator,
+        value: "**="
+      };
+    }
+	 
     if (ch1 === "!" && ch2 === "=" && ch3 === "=") {
       return {
         type: Token.Punctuator,
@@ -34142,7 +34149,7 @@ Lexer.prototype = {
 
     // 2-character punctuators: <= >= == != ++ -- << >> && ||
     // += -= *= %= &= |= ^= /=
-    if (ch1 === ch2 && ("+-<>&|".indexOf(ch1) >= 0)) {
+    if (ch1 === ch2 && ("+-<>*&|".indexOf(ch1) >= 0)) {
       return {
         type: Token.Punctuator,
         value: ch1 + ch2
@@ -41105,6 +41112,7 @@ var JSHINT = (function() {
   assignop("+=", "assignadd", 20);
   assignop("-=", "assignsub", 20);
   assignop("*=", "assignmult", 20);
+  assignop("**=", "assignexp", 20);
   assignop("/=", "assigndiv", 20).nud = function() {
     error("E014");
   };
@@ -41289,6 +41297,7 @@ var JSHINT = (function() {
     this.right = expression(130);
     return this;
   }, 130);
+  infix("**", "exp", 140);
   infix("*", "mult", 140);
   infix("/", "div", 140);
   infix("%", "mod", 140);

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -9383,6 +9383,7 @@
       if (arguments.length === 0 && bufferLen === 0) {
         Processing.logger.log("");
       } else if (arguments.length !== 0) {
+		  message = (typeof message === "symbol") ? message.toString() : message;
         Processing.logger.log(message);
       }
     };
@@ -9394,6 +9395,7 @@
      * @see #join
      */
     p.print = function(message) {
+		message = (typeof message === "symbol") ? message.toString() : message;
       logBuffer.push(message);
     };
 

--- a/build/js/live-editor.output_pjs_deps.js
+++ b/build/js/live-editor.output_pjs_deps.js
@@ -34147,7 +34147,7 @@ Lexer.prototype = {
       };
     }
 
-    // 2-character punctuators: <= >= == != ++ -- << >> && ||
+    // 2-character punctuators: <= >= == != ++ -- << >> && || **
     // += -= *= %= &= |= ^= /=
     if (ch1 === ch2 && ("+-<>*&|".indexOf(ch1) >= 0)) {
       return {
@@ -57821,7 +57821,7 @@ ASTTransforms.rewriteContextVariables = function (envName, context) {
 
                     // If the current variable declaration has an "init" value of null
                     //  (IE. no init value given to parser), and the current node type
-                    //  doesn't match "ForInStatement" (a for-in loop), exit the
+                    //  doesn't match "ForInStatement" (a for-in loop) or "ForOfStatement" (a for-of loop), exit the
                     //  function.
                     if (decl.init === null && parent.type !== "ForInStatement" && parent.type !== "ForOfStatement") {
                         return;

--- a/build/js/live-editor.tooltips.js
+++ b/build/js/live-editor.tooltips.js
@@ -564,7 +564,7 @@ window.ScratchpadAutosuggest = {
         // Local completer is currently disabled because it doesn't work
         // perfectly, even with wrapping it.  I think implementing a custom
         // one before enabling would be best.
-          // The internal local completer thinks numbers are identifiers
+         // The internal local completer thinks numbers are identifiers
         // and suggests them if they are used, get rid of that by
         // wrapping the internal local completer in our own!
         this.localVariableCompleter = {
@@ -575,7 +575,7 @@ window.ScratchpadAutosuggest = {
                         session, pos, prefix, callback);
                     return;
                 }
-                  if (prefix.length === 0) {
+                 if (prefix.length === 0) {
                     callback(null, []);
                 }
             }.bind(this)

--- a/build/js/live-editor.ui.js
+++ b/build/js/live-editor.ui.js
@@ -2347,7 +2347,7 @@ window.LiveEditor = Backbone.View.extend({
         $(".tipbar").css("width",(width - 140) +"px")
         this.$el.find(this.dom.CANVAS_WRAP).width(width);
         this.$el.find(this.dom.ALL_OUTPUT).height(height);
-          // Set the editor height to be the same as the canvas height
+         // Set the editor height to be the same as the canvas height
         this.$el.find(this.dom.EDITOR).height($(".scratchpad-canvas-wrap").height() - 46 - 8);*/
 
         this.$el.find(this.dom.OUTPUT_FRAME).css({

--- a/external/debugger/external/processing-js/processing.js
+++ b/external/debugger/external/processing-js/processing.js
@@ -9291,6 +9291,7 @@
       if (arguments.length === 0 && bufferLen === 0) {
         Processing.logger.log("");
       } else if (arguments.length !== 0) {
+		  message = (typeof message === "symbol") ? message.toString() : message;
         Processing.logger.log(message);
       }
     };
@@ -9302,6 +9303,7 @@
      * @see #join
      */
     p.print = function(message) {
+		message = (typeof message === "symbol") ? message.toString() : message;
       logBuffer.push(message);
     };
 

--- a/external/jshint/jshint.js
+++ b/external/jshint/jshint.js
@@ -13967,7 +13967,14 @@ Lexer.prototype = {
         value: "==="
       };
     }
-
+	 
+	 if (ch1 === "*" && ch2 === "*" && ch3 === "=") {
+      return {
+        type: Token.Punctuator,
+        value: "**="
+      };
+    }
+	 
     if (ch1 === "!" && ch2 === "=" && ch3 === "=") {
       return {
         type: Token.Punctuator,
@@ -14006,7 +14013,7 @@ Lexer.prototype = {
 
     // 2-character punctuators: <= >= == != ++ -- << >> && ||
     // += -= *= %= &= |= ^= /=
-    if (ch1 === ch2 && ("+-<>&|".indexOf(ch1) >= 0)) {
+    if (ch1 === ch2 && ("+-<>*&|".indexOf(ch1) >= 0)) {
       return {
         type: Token.Punctuator,
         value: ch1 + ch2
@@ -20969,6 +20976,7 @@ var JSHINT = (function() {
   assignop("+=", "assignadd", 20);
   assignop("-=", "assignsub", 20);
   assignop("*=", "assignmult", 20);
+  assignop("**=", "assignexp", 20);
   assignop("/=", "assigndiv", 20).nud = function() {
     error("E014");
   };
@@ -21153,6 +21161,7 @@ var JSHINT = (function() {
     this.right = expression(130);
     return this;
   }, 130);
+  infix("**", "exp", 140);
   infix("*", "mult", 140);
   infix("/", "div", 140);
   infix("%", "mod", 140);

--- a/external/jshint/jshint.js
+++ b/external/jshint/jshint.js
@@ -14011,7 +14011,7 @@ Lexer.prototype = {
       };
     }
 
-    // 2-character punctuators: <= >= == != ++ -- << >> && ||
+    // 2-character punctuators: <= >= == != ++ -- << >> && || **
     // += -= *= %= &= |= ^= /=
     if (ch1 === ch2 && ("+-<>*&|".indexOf(ch1) >= 0)) {
       return {

--- a/external/processing-js/processing.js
+++ b/external/processing-js/processing.js
@@ -9383,6 +9383,7 @@
       if (arguments.length === 0 && bufferLen === 0) {
         Processing.logger.log("");
       } else if (arguments.length !== 0) {
+		  message = (typeof message === "symbol") ? message.toString() : message;
         Processing.logger.log(message);
       }
     };
@@ -9394,6 +9395,7 @@
      * @see #join
      */
     p.print = function(message) {
+		message = (typeof message === "symbol") ? message.toString() : message;
       logBuffer.push(message);
     };
 

--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -224,13 +224,15 @@ ASTTransforms.rewriteContextVariables = function(envName, context) {
 
                             return {
                                 type: "SequenceExpression",
-                                expressions: node.declarations.map(decl => {
-                                    return b.AssignmentExpression(
-                                        b.MemberExpression(b.Identifier(envName),b.Identifier(decl.id.name)),
-                                        "=",
-                                        decl.init
-                                    );
-                                })
+                                expressions: node.declarations
+                                    .filter(d => d.init !== null)
+                                    .map(decl => {
+                                        return b.AssignmentExpression(
+                                            b.MemberExpression(b.Identifier(envName),b.Identifier(decl.id.name)),
+                                            "=",
+                                            decl.init
+                                        );
+                                    })
                             };
                         }
 

--- a/js/output/pjs/pjs-ast-transforms.js
+++ b/js/output/pjs/pjs-ast-transforms.js
@@ -150,7 +150,7 @@ ASTTransforms.rewriteContextVariables = function(envName, context) {
 
                     // If the current variable declaration has an "init" value of null
                     //  (IE. no init value given to parser), and the current node type
-                    //  doesn't match "ForInStatement" (a for-in loop), exit the
+                    //  doesn't match "ForInStatement" (a for-in loop) or "ForOfStatement" (a for-of loop), exit the
                     //  function.
                     if (decl.init === null && parent.type !== "ForInStatement" && parent.type !== "ForOfStatement") {
                         return;

--- a/js/output/pjs/pjs-code-injector.js
+++ b/js/output/pjs/pjs-code-injector.js
@@ -132,6 +132,7 @@ class PJSCodeInjector {
             this.processing.isNaN = window.isNaN;
             this.processing.Number = window.Number;
             this.processing.Date = window.Date;
+			   this.processing.Symbol = window.Symbol;
         }
 
         Object.assign(this.processing, {


### PR DESCRIPTION
* `println`/`print` convert `Symbol`s to strings before logging them to avoid the `Cannot convert a Symbol value to a string` error.
* Edited JSHint to support `**` and `**=`.